### PR TITLE
Fix script so print statements show up in job logs

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -13,18 +13,19 @@ ray.client().connect()
 #ray.client("anyscale://cluster-1").cluster_compute("anastasia_def").connect()
 
 # iterate through a loop x times, running batches of size y
-def get_next_nth_fib(n,batch_size):
-    fib_actor = Fibs.remote()
-    fibs = []
-    for i in range(0,n):
-        fibs.append(fib_actor.next_n.remote(batch_size))
-    result = [ray.get(x) for x in fibs]
-    timestamper()
-    return result
-
 @ray.remote
 def run_job():
     timestamper = TimeStamper()
+
+    def get_next_nth_fib(n,batch_size):
+        fib_actor = Fibs.remote()
+        fibs = []
+        for i in range(0,n):
+            fibs.append(fib_actor.next_n.remote(batch_size))
+        result = [ray.get(x) for x in fibs]
+        timestamper()
+        return result
+
     print("Starting Run, generating one number with each invocation")
     print(get_next_nth_fib(200,1))
     print("Starting Run, generating ten numbers with each invocation")

--- a/driver.py
+++ b/driver.py
@@ -12,8 +12,6 @@ ray.client().connect()
 # The connection can also be expressed in code
 #ray.client("anyscale://cluster-1").cluster_compute("anastasia_def").connect()
 
-
-timestamper = TimeStamper()
 # iterate through a loop x times, running batches of size y
 def get_next_nth_fib(n,batch_size):
     fib_actor = Fibs.remote()
@@ -24,15 +22,18 @@ def get_next_nth_fib(n,batch_size):
     timestamper()
     return result
 
-print("Starting Run, generating one number with each invocation")
-print(get_next_nth_fib(200,1))
-print("Starting Run, generating ten numbers with each invocation")
-print(get_next_nth_fib(20,10))
-print("Starting Run, generating 100 numbers with each invocation")
-print(get_next_nth_fib(2,100))
-print("Starting Run, generating all 200 numbers in one go")
-print(get_next_nth_fib(1,200))
+@ray.remote
+def run_job():
+    timestamper = TimeStamper()
+    print("Starting Run, generating one number with each invocation")
+    print(get_next_nth_fib(200,1))
+    print("Starting Run, generating ten numbers with each invocation")
+    print(get_next_nth_fib(20,10))
+    print("Starting Run, generating 100 numbers with each invocation")
+    print(get_next_nth_fib(2,100))
+    print("Starting Run, generating all 200 numbers in one go")
+    print(get_next_nth_fib(1,200))
 
-print(timestamper)
+    print(timestamper)
 
 

--- a/driver.py
+++ b/driver.py
@@ -35,5 +35,7 @@ def run_job():
     print(get_next_nth_fib(1,200))
 
     print(timestamper)
+    
+ray.get(run_job.remote())
 
 


### PR DESCRIPTION
Unfortunately, we cannot easily capture the print statements that occur on the user's laptop. The job logs only show print statements that occur in the ray cluster.

This simple workaround can be documented as a recommended pattern.